### PR TITLE
Fix memory limits in test configs for devcontainer compatibility

### DIFF
--- a/conf/test_absrel.config
+++ b/conf/test_absrel.config
@@ -16,6 +16,10 @@ process {
         memory: '15.GB',
         time: '1.h'
     ]
+
+    withLabel:process_single {
+        memory = { 3.GB * task.attempt }
+    }
 }
 
 params {

--- a/conf/test_busted.config
+++ b/conf/test_busted.config
@@ -16,6 +16,10 @@ process {
         memory: '15.GB',
         time: '1.h'
     ]
+
+    withLabel:process_single {
+        memory = { 3.GB * task.attempt }
+    }
 }
 
 params {

--- a/conf/test_meme.config
+++ b/conf/test_meme.config
@@ -16,6 +16,13 @@ process {
         memory: '15.GB',
         time: '1.h'
     ]
+
+    withLabel:process_single {
+        memory = { 3.GB * task.attempt }
+    }
+    withLabel:process_low {
+        memory = { 3.GB * task.attempt }
+    }
 }
 
 params {

--- a/conf/test_relax.config
+++ b/conf/test_relax.config
@@ -16,6 +16,10 @@ process {
         memory: '15.GB',
         time: '1.h'
     ]
+
+    withLabel:process_single {
+        memory = { 3.GB * task.attempt }
+    }
 }
 
 params {

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,0 +1,30 @@
+{
+    "-profile test": {
+        "content": [
+            {
+                "HYPHY_ABSREL": {
+                    "hyphy": "2.5.96(MP)"
+                },
+                "Workflow": {
+                    "nf-core/phyloanalysis": "v1.0.0dev"
+                }
+            },
+            [
+                "absrel",
+                "absrel/KSR2_ABSREL.json",
+                "absrel/KSR2_ABSREL_output.txt",
+                "pipeline_info",
+                "pipeline_info/nf_core_phyloanalysis_software_mqc_versions.yml"
+            ],
+            [
+                "KSR2_ABSREL.json:md5,93a862faed1f3e647e4560bad4df8356",
+                "KSR2_ABSREL_output.txt:md5,5fffa950766e6b74d3b5064417c359fc"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-03-11T19:07:03.529718053"
+    }
+}


### PR DESCRIPTION
Fix memory limits in test configs for devcontainer compatibility
                                                                                                         
 The process_single label in base.config requests 6 GB and process_low requests 12 GB by default. The   
 nf-core devcontainer only has ~3.5 GB available, causing all test profile runs to fail immediately with a memory requirement error before any tool executes.
 This PR overrides memory limits in each per-tool test config to 3 GB, allowing tests to run successfully inside the devcontainer. Also includes the generated nf-test snapshot for test_absrel.
